### PR TITLE
feat: Automagically add usr/share to deb install file when man pages …

### DIFF
--- a/cpkg/lib/deb/libpackage.sh
+++ b/cpkg/lib/deb/libpackage.sh
@@ -85,6 +85,18 @@ function lp_handle_package_files() {
         fi
     done
 
+    # Fixup install file to include 'usr/share' dir wherever
+    # man page are present
+    local DPKG_INSTALL_FILE=$PKG_ROOTDIR/debian/$PKG_NAME.install
+    local MANDIR=$PKG_STAGEDIR/$PKG_MANDIR
+    local USR_SHARE='usr/share'
+
+    if [[ -d ${MANDIR} ]];then
+        if [[ $(grep -c "${USR_SHARE}" ${DPKG_INSTALL_FILE}) ==  "0" ]];then
+        echo ${USR_SHARE} >> ${DPKG_INSTALL_FILE}
+        fi
+    fi
+
     local FILES=$(find $PKG_ROOTDIR/debian -maxdepth 1 -type f | xargs)
 
     local TAG="##"


### PR DESCRIPTION
…are present.

usr/share is only added to install file when share directory is present in $PKG_SOURCEDIR
This leads to a situation where generated man pages are not embedded in the package if the 'share' directory is absent.

In such event, the proposed change add the required include path to the install file
